### PR TITLE
Fixed read_varargin.m

### DIFF
--- a/read_varargin.m
+++ b/read_varargin.m
@@ -15,6 +15,7 @@
 %==========================================================================
 function out = read_varargin(in, s_name, s_default)
 
+s_name = cellstr(s_name);
 n = length(s_name);
 
 % Set the default values


### PR DESCRIPTION
When in is "string", such as 
```matlab
s_name = {"Time_type"};
out{j} = {"Time_type"};
```
the result of "strcmpi(s_name, out{j});"  is 0